### PR TITLE
Var to const for compatibility with Safari

### DIFF
--- a/content.js
+++ b/content.js
@@ -42,7 +42,7 @@ if (window.contentScriptInjected !== true) {
         "Č": "Ч",
         "Č": "Ч", // C with caron
         "DŽ": "Џ",
-        "Ǆ": "Џ", 
+        "Ǆ": "Џ",
         "DŽ": "Џ", // D + Z with caron
         //"DZ": "Џ",
         "Dž": "Џ",
@@ -420,7 +420,7 @@ if (window.contentScriptInjected !== true) {
         return trie;
     }
 
-    const trie = buildTrie(initialMap);
+    var trie = buildTrie(initialMap);
     console.log("Ћирилизатор - Caching and replacing text on page " + window.location.href);
     processText(document, 'cache-replace');
 

--- a/content.js
+++ b/content.js
@@ -99,7 +99,7 @@ if (window.contentScriptInjected !== true) {
 
 
     // Temporary fix for United Media sites with faulty "Exo 2" font.
-    const fontAffectedSites = [
+    var fontAffectedSites = [
         "ba.n1info.com",
         "hr.n1info.com",
         "rs.n1info.com",
@@ -112,7 +112,7 @@ if (window.contentScriptInjected !== true) {
     }
 
 
-    const serbianWordsWithForeignCharacterCombinations = [
+    var serbianWordsWithForeignCharacterCombinations = [
         "aparthejd",
         "ddor",
         "dss",
@@ -141,7 +141,7 @@ if (window.contentScriptInjected !== true) {
         "urla",
     ];
 
-    const commonForeignWords = [
+    var commonForeignWords = [
         "administration",
         "adobe",
         "advanced",
@@ -245,7 +245,7 @@ if (window.contentScriptInjected !== true) {
         "visa",
     ];
 
-    const foreignCharacterCombinations = [
+    var foreignCharacterCombinations = [
         'q',
         'w',
         'x',
@@ -285,7 +285,7 @@ if (window.contentScriptInjected !== true) {
         '.org'
     ];
 
-    const digraphExceptions = {
+    var digraphExceptions = {
         "dj": [
             "adjektiv",
             "adjunkt",
@@ -379,7 +379,7 @@ if (window.contentScriptInjected !== true) {
     };
 
     // See: https://en.wikipedia.org/wiki/Zero-width_non-joiner
-    const digraphReplacements = {
+    var digraphReplacements = {
         "dj": {
             "dj": "d\u200Cj",
             "Dj": "D\u200Cj",


### PR DESCRIPTION
Safari throws reference errors such as "Can't find variable: serbianWordsWithForeignCharacterCombinations" etc. if they are declared as constants and not variables, which makes the Cirilizer fail. This is a scoping issue.

I don't think it would matter to Chrome & co. if you used variables instead of constants, but that should be checked, of course. 

My hope is that with these changes we'll be able to keep our Safari extension more easily in sync with the others. 