### PR TITLE
Исправка бага при транслитерацији

### DIFF
--- a/content.js
+++ b/content.js
@@ -909,7 +909,7 @@ if (window.contentScriptInjected !== true) {
      * Trims white spaces and punctuation marks from the start and the end of the word.
      */
     function trimExcessiveCharacters(word) {
-        const excessiveChars = "[\-\\s!?,:;.\*—~`'\"“(){}\\[\\]<>\\/]";
+        const excessiveChars = "[\\s!?,:;.\*\\-—~`'\"„”“”‘’(){}\\[\\]<>«»\\/\\\\]";
         const regExp = new RegExp("^(" + excessiveChars + ")+|(" + excessiveChars + ")+$", "g");
 
         return word.replace(regExp, '');

--- a/content.js
+++ b/content.js
@@ -248,9 +248,10 @@ if (window.contentScriptInjected !== true) {
         "cpu",
         "dj",
         "electronics",
+        "fun",
         "gmbh",
-        "ii", 
-        "iii", 
+        "ii",
+        "iii",
         "khz",
         "live",
         "login",
@@ -763,7 +764,7 @@ if (window.contentScriptInjected !== true) {
     }
 
     function looksLikeForeignWord(word) {
-        word = word.trim().toLowerCase();
+        word = trimExcessiveCharacters(word).toLowerCase();
         if (word === "") {
             return false;
         }
@@ -888,7 +889,7 @@ if (window.contentScriptInjected !== true) {
      * Example: dj-evi should be transliterated as dj-еви so the function retrieves 3.
      */
     function transliterationIndexOfWordStartsWith(word, array, charSeparator) {
-        word = word.trim().toLowerCase();
+        word = trimExcessiveCharacters(word).toLowerCase();
         if (word === "") {
             return -1;
         }
@@ -902,6 +903,16 @@ if (window.contentScriptInjected !== true) {
         }
 
         return -1;
+    }
+
+    /*
+     * Trims white spaces and punctuation marks from the start and the end of the word.
+     */
+    function trimExcessiveCharacters(word) {
+        const excessiveChars = "[\-\\s!?,:;.\*—~`'\"“(){}\\[\\]<>\\/]";
+        const regExp = new RegExp("^(" + excessiveChars + ")+|(" + excessiveChars + ")+$", "g");
+
+        return word.replace(regExp, '');
     }
 
 }


### PR DESCRIPTION
У неким случајевима речи којима претходе знакови интерпункције или након којих одмах следи знак интерпункције нису биле ћирилизоване. 
Неки од примера су на следећим страницама:
- https://www.b92.net/bbc/index.php?yyyy=2020&mm=11&dd=05&nav_id=1758940
'Samo да ти се захвалимо, ово смо ми'
->
'Само да ти се захвалимо, ово смо ми'
- https://rs.n1info.com/vesti/stefanovic-ssp-sve-vise-ljudi-shvata-da-nije-normalno-da-posao-zavisi-od-sns/
Стефановић (SSP)
->
Стефановић (ССП)
- https://www.vice.com/sr/article/7xmgyz/sta-bi-sve-moglo-da-se-pre
Постани дипломирани Ђ!
->
Postani diplomirani DJ!
- https://voxfeminae.net/feministyle/intervju-alma-fazlic-dj-sefika/i
“Ђ-исање ми је уствари кренуло
->
“DJ-isanje mi je ustvari krenulo