### PR TITLE
Сајт www.novosti.rs се не пресловљава на ћирилицу у целости

### DIFF
--- a/background.js
+++ b/background.js
@@ -222,6 +222,7 @@ chrome.runtime.onInstalled.addListener(function () {
             'www.novaenergija.net',
             'www.novimagazin.rs',
             'www.novine.ca',
+            'www.novosti.rs',
             'www.nuns.rs',
             'www.okradio.rs',
             'www.personalmag.rs',

--- a/background.js
+++ b/background.js
@@ -28,7 +28,7 @@ var redirects = [
     , { enabled: false, filter: '*://www.kragujevac.rs/*',        rules: [ { match: '^(https?)://www.kragujevac.rs/(.*)?script=lat$',                 redirect: '$1://www.kragujevac.rs/$2?script=cir'        }
                                                                          , { match: '^(https?)://www.kragujevac.rs/((?!.*\?script=(?:cir|lat)).*)',   redirect: '$1://www.kragujevac.rs/$2?script=cir'        } ] }
     , { enabled: false, filter: '*://www.mod.gov.rs/*',           rules: [ { match: '^(https?)://www.mod.gov.rs/lat(.*)$',                            redirect: '$1://www.mod.gov.rs/cir$2'                   } ] }
-    , { enabled: false, filter: '*://www.novosti.rs/*',           rules: [ { match: '^(https?)://www.novosti.rs/(?!c/)(.*?)$',                        redirect: '$1://www.novosti.rs/c/$2'                    } ] }
+//    , { enabled: false, filter: '*://www.novosti.rs/*',           rules: [ { match: '^(https?)://www.novosti.rs/(?!c/)(.*?)$',                        redirect: '$1://www.novosti.rs/c/$2'                    } ] }
     , { enabled: false, filter: '*://www.nspm.rs/*',              rules: [ { match: '^(https?)://www.nspm.rs/(.*)?alphabet=l$',                       redirect: '$1://www.nspm.rs/$2?alphabet=c'              } ] }
     , { enabled: false, filter: '*://www.politika.rs/*',          rules: [ { match: '^(https?)://www.politika.rs/sr(/?)(.*)$',                        redirect: '$1://www.politika.rs/scc$2$3'                } ] }
     , { enabled: false, filter: '*://posta.rs/*',                 rules: [ { match: '^(https?)://(?:.*\.)?posta.rs/lat/(.*)$',                        redirect: '$1://posta.rs/cir/$2'                        }


### PR DESCRIPTION
Сајт новости се редиректује на њихову ћириличну варијанту. Међутим, они не пресловљавају цео садржај на ћирилицу.
Можда постоји неко боље решење, али најлакше је да се уклони сајт из листе за редирекцију. 
Редирекцију сам оставио закоментарисану, као документација да је проблем познат.
![novosti](https://user-images.githubusercontent.com/30440470/118392400-e073ab00-b639-11eb-8e96-fd1c88330b37.png)
