### PR TITLE
Раздвајање речи не само са размаком

### DIFF
--- a/content.js
+++ b/content.js
@@ -802,7 +802,7 @@ if (window.contentScriptInjected !== true) {
             }
         }
 
-        return words.join(' ');
+        return words.join('');
     }
 
     function looksLikeForeignWord(word) {

--- a/content.js
+++ b/content.js
@@ -791,7 +791,7 @@ if (window.contentScriptInjected !== true) {
             return text;
         }
 
-        let words = text.split(' ');
+        let words = text.split(/(\s+)/);
 
         for (let i = 0, length = words.length; i < length; i++) {
             let index = transliterationIndexOfWordStartsWith(words[i], wholeForeignWords, "-");


### PR DESCRIPTION
Када се између речи налази нпр. TAB уместо размака, стране речи ће бити транслитериране на ћирилицу.
Овим се то поправља.