### PR TITLE
Изостављање пресловљавања мерних јединица

### DIFF
--- a/content.js
+++ b/content.js
@@ -213,7 +213,6 @@ if (window.contentScriptInjected !== true) {
         "maps",
         "mastercard",
         "mercator",
-        "mhz",
         "microsoft",
         "mitsubishi",
         "notebook",
@@ -272,12 +271,10 @@ if (window.contentScriptInjected !== true) {
         "hair",
         "have",
         "home",
-        "hz",
         "ii",
         "iii",
         "idj",
         "idjtv",
-        "khz",
         "life",
         "live",
         "login",
@@ -335,7 +332,7 @@ if (window.contentScriptInjected !== true) {
         '.org',
         '©',
         '®',
-        '™'
+        '™',
     ];
 
     var digraphExceptions = {
@@ -838,8 +835,13 @@ if (window.contentScriptInjected !== true) {
             return true;
         }
 
+        if (wordContainsMeasurementUnit(word)) {
+            return true;
+        }
+
         return false;
     }
+
 
     function wordToCyrillic(word) {
         word = splitDigraphs(word);
@@ -930,6 +932,20 @@ if (window.contentScriptInjected !== true) {
             if (word === arrayWord) {
                 return true;
             }
+        }
+
+        return false;
+    }
+
+    function wordContainsMeasurementUnit(word) {
+        const unitAdjacentToSth = "([zafpnμmcdhKMGTPEY]?([BVWJFSHCΩATNhlmg]|m[²³]|s[²]|cd|Pa|Wb|Hz))";
+        const unitOptionalyAdjacentToSth = "(°[FC]|[kMGTPEY](B|Hz)|[pnμmcdhk]m[²³]?|m[²³]|[mcdkh][lg])";
+        const number = "(\\d+([\.,]\\d)*)";
+        const regExp = new RegExp("^("+ number + unitAdjacentToSth + ")|("
+            + number + "?(" + unitOptionalyAdjacentToSth + "|" + unitAdjacentToSth + "/" + unitAdjacentToSth + "))$", "gi");
+
+        if (word.match(regExp)) {
+            return true;
         }
 
         return false;


### PR DESCRIPTION
Мерне јединице попут °C су до сада биле пресловљаване.
Овим се омогућује да најчешће остану у свом изворном облику.

У коду постоје два случаја описана регуларним изразима:
- unitAdjacentToSth 
- unitOptionalyAdjаcentToSth

Први израз обухвата случај када се мерна јединица налази прилепљена уз број нпр. 23MB или знак дељења нпр. km/h.
Други израз обухвата случај када мерна јединица стоји сама за себе као реч нпр. m/s, а опционо може бити прилепљена уз број нпр. 14,5m/s.

Други израз је рестриктивнији и не узима у обзир све мерне јединице, да се не би увек пресловљавало када стоји само за себе нпр. m, s итд.

За тест могу послужити странице овог сајта: https://fizikalac.wixsite.com/fizikalac/6-ravnomerno-pravolinijsko-kre
