### PR TITLE
Revert "Remove www.novosti.rs from the list of redirected sites."

### DIFF
--- a/background.js
+++ b/background.js
@@ -28,7 +28,7 @@ var redirects = [
     , { enabled: false, filter: '*://www.kragujevac.rs/*',        rules: [ { match: '^(https?)://www.kragujevac.rs/(.*)?script=lat$',                 redirect: '$1://www.kragujevac.rs/$2?script=cir'        }
                                                                          , { match: '^(https?)://www.kragujevac.rs/((?!.*\?script=(?:cir|lat)).*)',   redirect: '$1://www.kragujevac.rs/$2?script=cir'        } ] }
     , { enabled: false, filter: '*://www.mod.gov.rs/*',           rules: [ { match: '^(https?)://www.mod.gov.rs/lat(.*)$',                            redirect: '$1://www.mod.gov.rs/cir$2'                   } ] }
-//    , { enabled: false, filter: '*://www.novosti.rs/*',           rules: [ { match: '^(https?)://www.novosti.rs/(?!c/)(.*?)$',                        redirect: '$1://www.novosti.rs/c/$2'                    } ] }
+    , { enabled: false, filter: '*://www.novosti.rs/*',           rules: [ { match: '^(https?)://www.novosti.rs/(?!c/)(.*?)$',                        redirect: '$1://www.novosti.rs/c/$2'                    } ] }
     , { enabled: false, filter: '*://www.nspm.rs/*',              rules: [ { match: '^(https?)://www.nspm.rs/(.*)?alphabet=l$',                       redirect: '$1://www.nspm.rs/$2?alphabet=c'              } ] }
     , { enabled: false, filter: '*://www.politika.rs/*',          rules: [ { match: '^(https?)://www.politika.rs/sr(/?)(.*)$',                        redirect: '$1://www.politika.rs/scc$2$3'                } ] }
     , { enabled: false, filter: '*://posta.rs/*',                 rules: [ { match: '^(https?)://(?:.*\.)?posta.rs/lat/(.*)$',                        redirect: '$1://posta.rs/cir/$2'                        }
@@ -234,7 +234,6 @@ chrome.runtime.onInstalled.addListener(function () {
             'www.novaenergija.net',
             'www.novimagazin.rs',
             'www.novine.ca',
-            'www.novosti.rs',
             'www.nuns.rs',
             'www.okradio.rs',
             'www.personalmag.rs',


### PR DESCRIPTION
Образложење (овде https://github.com/turanjanin/cirilizator/pull/25) за уклањање Новости са редирекције није до редирекције него до самог сајта Новости. Садржај који корисник долази да чита на сајту Новости је исправно пресловљен, а делови њиховог придруженог садржаја није. Предности редирекције је да ће се повећати посета на ћириличну верзију сајта, што би као резултат требало да мотивише администраторе да поправе придружени садржај да и он буде ћирилични.
