### PR TITLE
Deleted case insensitive in measurement regex

### DIFF
--- a/content.js
+++ b/content.js
@@ -818,7 +818,8 @@ if (window.contentScriptInjected !== true) {
     }
 
     function looksLikeForeignWord(word) {
-        word = trimExcessiveCharacters(word).toLowerCase();
+        trimmedWord = trimExcessiveCharacters(word);
+        word = trimmedWord.toLowerCase();
         if (word === "") {
             return false;
         }
@@ -839,7 +840,7 @@ if (window.contentScriptInjected !== true) {
             return true;
         }
 
-        if (wordContainsMeasurementUnit(trimExcessiveCharacters(word))) {
+        if (wordContainsMeasurementUnit(trimmedWord)) {
             return true;
         }
 
@@ -943,7 +944,7 @@ if (window.contentScriptInjected !== true) {
 
     function wordContainsMeasurementUnit(word) {
         const unitAdjacentToSth = "([zafpnμmcdhKMGTPEY]?([BVWJFSHCΩATNhlmg]|m[²³]|s[²]|cd|Pa|Wb|Hz))";
-        const unitOptionalyAdjacentToSth = "(°[FC]|[kMGTPEY](B|Hz)|[pnμmcdhk]m[²³]?|m[²³]|[mcdkh][lg])";
+        const unitOptionalyAdjacentToSth = "(°[FC]|[kMGTPZY](B|Hz)|[pnμmcdhk]m[²³]?|m[²³]|[mcdkh][lg])";
         const number = "(\\d+([\.,]\\d)*)";
         const regExp = new RegExp("^("+ number + unitAdjacentToSth + ")|("
             + number + "?(" + unitOptionalyAdjacentToSth + "|" + unitAdjacentToSth + "/" + unitAdjacentToSth + "))$");

--- a/content.js
+++ b/content.js
@@ -943,8 +943,8 @@ if (window.contentScriptInjected !== true) {
     }
 
     function wordContainsMeasurementUnit(word) {
-        const unitAdjacentToSth = "([zafpnμmcdhKMGTPEY]?([BVWJFSHCΩATNhlmg]|m[²³]|s[²]|cd|Pa|Wb|Hz))";
-        const unitOptionalyAdjacentToSth = "(°[FC]|[kMGTPZY](B|Hz)|[pnμmcdhk]m[²³]?|m[²³]|[mcdh][lg])"; // deleted kilo
+        const unitAdjacentToSth = "([zafpnμmcdhKMGTPEY]?([BVWJFSHCΩATNhlmg]|m[²³]?|s[²]?|cd|Pa|Wb|Hz))";
+        const unitOptionalyAdjacentToSth = "(°[FC]|[kMGTPZY](B|Hz)|[pnμmcdhk]m[²³]?|m[²³]|[mcdh][lg]|kg|km)";
         const number = "(\\d+([\.,]\\d)*)";
         const regExp = new RegExp("^(" + number + unitAdjacentToSth + ")|("
             + number + "?(" + unitOptionalyAdjacentToSth + "|" + unitAdjacentToSth + "/" + unitAdjacentToSth + "))$");

--- a/content.js
+++ b/content.js
@@ -839,7 +839,7 @@ if (window.contentScriptInjected !== true) {
             return true;
         }
 
-        if (wordContainsMeasurementUnit(word)) {
+        if (wordContainsMeasurementUnit(trimExcessiveCharacters(word))) {
             return true;
         }
 
@@ -946,7 +946,7 @@ if (window.contentScriptInjected !== true) {
         const unitOptionalyAdjacentToSth = "(°[FC]|[kMGTPEY](B|Hz)|[pnμmcdhk]m[²³]?|m[²³]|[mcdkh][lg])";
         const number = "(\\d+([\.,]\\d)*)";
         const regExp = new RegExp("^("+ number + unitAdjacentToSth + ")|("
-            + number + "?(" + unitOptionalyAdjacentToSth + "|" + unitAdjacentToSth + "/" + unitAdjacentToSth + "))$", "gi");
+            + number + "?(" + unitOptionalyAdjacentToSth + "|" + unitAdjacentToSth + "/" + unitAdjacentToSth + "))$");
 
         if (word.match(regExp)) {
             return true;

--- a/content.js
+++ b/content.js
@@ -818,7 +818,7 @@ if (window.contentScriptInjected !== true) {
     }
 
     function looksLikeForeignWord(word) {
-        trimmedWord = trimExcessiveCharacters(word);
+        let trimmedWord = trimExcessiveCharacters(word);
         word = trimmedWord.toLowerCase();
         if (word === "") {
             return false;
@@ -944,9 +944,9 @@ if (window.contentScriptInjected !== true) {
 
     function wordContainsMeasurementUnit(word) {
         const unitAdjacentToSth = "([zafpnμmcdhKMGTPEY]?([BVWJFSHCΩATNhlmg]|m[²³]|s[²]|cd|Pa|Wb|Hz))";
-        const unitOptionalyAdjacentToSth = "(°[FC]|[kMGTPZY](B|Hz)|[pnμmcdhk]m[²³]?|m[²³]|[mcdkh][lg])";
+        const unitOptionalyAdjacentToSth = "(°[FC]|[kMGTPZY](B|Hz)|[pnμmcdhk]m[²³]?|m[²³]|[mcdh][lg])"; // deleted kilo
         const number = "(\\d+([\.,]\\d)*)";
-        const regExp = new RegExp("^("+ number + unitAdjacentToSth + ")|("
+        const regExp = new RegExp("^(" + number + unitAdjacentToSth + ")|("
             + number + "?(" + unitOptionalyAdjacentToSth + "|" + unitAdjacentToSth + "/" + unitAdjacentToSth + "))$");
 
         if (word.match(regExp)) {


### PR DESCRIPTION
Case insensitive regex caused some false negative words. This PR fixes that regex.
Test pages: [хлеб](https://www.argeta.com/rs/spread-love/items/recept-za-ukusan-domaci-hleb/), [жреб](https://sport.blic.rs/kosarka/svetska-kosarka/srbija-u-prvom-sesiru-orlovi-u-utorak-tacno-u-podne-dobijaju-rivale-na-putu-ka/hw02lme), [спектакл](https://www.danas.rs/vesti/drustvo/ocekujem-spektakl-u-areni/)