### PR TITLE
Add gspns.co.rs to redirected domains

### DIFF
--- a/background.js
+++ b/background.js
@@ -54,6 +54,7 @@ var redirects = [
     , { enabled: false, filter: '*://www.ossrb.org/*',            rules: [ { match: '^(https?)://www.ossrb.org/(.*)?#lat$',                           redirect: '$1://www.ossrb.org/$2#cyr'                   } ] }
     , { enabled: false, filter: '*://www.etf.bg.ac.rs/*',         rules: [ { match: '^(https?)://www.etf.bg.ac.rs/sr-lat/(.*)$',                      redirect: '$1://www.etf.bg.ac.rs/sr/$2'                 } ] }
     , { enabled: false, filter: '*://www.tf.uns.ac.rs/*',         rules: [ { match: '^(https?)://www.tf.uns.ac.rs/(.*)?#lat$',                        redirect: '$1://www.tf.uns.ac.rs/$2#cyr'                } ] }
+    , { enabled: false, filter: '*://www.gspns.co.rs/*',          rules: [ { match: '^(https?)://www.gspns.co.rs/(.*)?selected_lang=lat$',            redirect: '$1://www.nspm.rs/$2?selected_lang=cir'       } ] }
 ];
 
 function matchRule(url, rule) {


### PR DESCRIPTION
На овом [сајту](http://www.gspns.co.rs/red-voznje/gradski?selected_lang=cir) је слична ситуација као и за Новости (#37), само је у мањој мери коришћена латиница. Наиме, приликом излиставања аутобуских линија и смерова, приказује се садржај са сервера који је на латиници.
![image](https://user-images.githubusercontent.com/40705899/204140457-bc1b854b-a93e-4dd5-8ed8-408244c5fc6d.png)

Сматрам да би ипак требали користити редирекцију, како бисмо указали администраторима да поправе приказ на ћириличној верзији.