### PR TITLE
fix: new n1 domains

### DIFF
--- a/background.js
+++ b/background.js
@@ -166,6 +166,7 @@ chrome.runtime.onInstalled.addListener(function () {
             'nationalgeographic.rs',
             'newsflash.rs',
             'niskevesti.rs',
+            'n1info.rs',
             'noizz.rs',
             'nova.rs',
             'novimagazin.rs',

--- a/content.js
+++ b/content.js
@@ -117,6 +117,9 @@ if (window.contentScriptInjected !== true) {
         "ba.n1info.com",
         "hr.n1info.com",
         "rs.n1info.com",
+        "n1info.ba",
+        "n1info.hr",
+        "n1info.rs",
         "sportklub.rs",
     ];
     if (fontAffectedSites.includes(window.location.hostname)) {


### PR DESCRIPTION
N1 променио домене на српском, хрватском и босанском сајту. Овај PR додаје нове домене (n1info.rs, n1info.hr и n1info.ba). Нисам брисао старе за сваки случај. 