### PR TITLE
rm unnecessary fontAffectedSites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
 .idea/
+.DS_Store
+*.xcuserstate

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 .idea/
 *.swp
+.DS_Store

--- a/content.js
+++ b/content.js
@@ -113,20 +113,13 @@ if (window.contentScriptInjected !== true) {
 
 
     // Temporary fix for United Media sites with faulty "Exo 2" font.
-    var fontAffectedSites = [
-        "ba.n1info.com",
-        "hr.n1info.com",
-        "rs.n1info.com",
-        "n1info.ba",
-        "n1info.hr",
-        "n1info.rs",
-        "sportklub.rs",
-    ];
-    if (fontAffectedSites.includes(window.location.hostname)) {
-        initialMap["đ"] = "ћ";
-        initialMap["ć"] = "ђ";
-        initialMap["ć"] = "ђ";
-    }
+    // var fontAffectedSites = [
+    // ];
+    // if (fontAffectedSites.includes(window.location.hostname)) {
+    //     initialMap["đ"] = "ћ";
+    //     initialMap["ć"] = "ђ";
+    //     initialMap["ć"] = "ђ";
+    // }
 
     var serbianWordsWithForeignCharacterCombinations = [
         "alchajmer",


### PR DESCRIPTION
N1 websites no longer need the character substitution hack. I've commented out the character mapping —  in case we run into the same problem on some other website. 