### PR TITLE
Пресловљавање диграф изузетка у заградама

### DIFF
--- a/content.js
+++ b/content.js
@@ -908,7 +908,7 @@ if (window.contentScriptInjected !== true) {
     }
 
     function splitDigraphs(str) {
-        const lowercaseStr = str.trim().toLowerCase();
+        const lowercaseStr = trimExcessiveCharacters(str).toLowerCase();
 
         for (const digraph in digraphExceptions) {
             if (!lowercaseStr.includes(digraph)) {


### PR DESCRIPTION
На страници https://direktno.rs/izbori-2024/526191/izborne-liste-beograd.html Ћирилизатор не узима у обзир изузетак код диграфа ако се реч која почиње диграфом налази у заградама. Исто је понашање и за друге окружујуће карактере. У конкретном случају долази до следећег пресловљавања `(ДЈБ) -> (ЂБ)`.

Овим се овакво понашање Ћирилизатора поправља.