### PR TITLE
Add gg to the list of serbian words with foreign characters

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -131,6 +131,7 @@ if (window.contentScriptInjected !== true) {
         "dvadesettrog",
         "epp",
         "fss",
+        "gg",
         "gss",
         "interreakc",
         "interresor",


### PR DESCRIPTION
Додаје gg као скраћеницу за Групу Грађана у листу српских речи са страним карактерима. Пример странице: [линк](https://n1info.rs/vesti/gik-novog-sada-odbila-izbornu-listu-gg-budi-heroj-misa-ronin-baculov/) 

